### PR TITLE
[FEATURE] Ne permettre que les guillemets simples

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,5 +18,6 @@ module.exports = {
     'declaration-colon-space-before': 'never',
     'declaration-block-semicolon-space-before': 'never',
     'block-opening-brace-space-before': 'always',
+    'string-quotes': 'single',
   },
 };


### PR DESCRIPTION
## :unicorn: Problème
Nous n'avons pas d'uniformité sur le format de marqueur de chaînes de caractères.

### Stats

<table>
<tr>
	<td><strong>Appli
	<td><strong>Nb correctifs estimé si migration vers guillemets simples
	<td><strong>Nb correctifs estimé si migration vers guillemets doubles
<tr>
	<td>Pix UI
	<td>29
	<td>73
<tr>
	<td>Mon Pix
	<td>0
	<td>467
<tr>
	<td>Admin
	<td>8
	<td>81
<tr>
	<td>Orga
	<td>32
	<td>129
<tr>
	<td>Certif
	<td>77
	<td>0
<tr>
	<td>Epreuves
	<td>29
	<td>64
<tr>
	<td>Editor
	<td>6
	<td>32
<tr>
	<td>Total
	<td>181
	<td>846
</table>

## :robot: Proposition
Utiliser des guillemets simples.

## :rainbow: Remarques
RAS

## :100: Pour tester
Ajouter la même règle sur une de nos applis et constater qu'elle fonctionne.
