### PR TITLE
[TECH] Corrige la `release`

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/1024pix/stylelint-config-pix.git"
+    "url": "git+https://github.com/1024pix/stylelint-config.git"
   },
-  "homepage": "https://github.com/1024pix/stylelint-config-pix#readme"
+  "homepage": "https://github.com/1024pix/stylelint-config#readme"
 }


### PR DESCRIPTION
## :unicorn: Problème
La `release` ne fonctionne pas, on se prend une 500 côté GitHub lors de la création de la release. En déroulant la bobine, on se rend compte que semantic release se base sur la clé `repository.url` du `package.json`. Le repo GitHub a changé d'URL mais le package.json n'a pas suivi...

## :robot: Proposition
Réaligner les clés du package.json avec le bon nom de repo.

## :rainbow: Remarques
RAS...

## :100: Pour tester
🤷 